### PR TITLE
Regenerate clientId

### DIFF
--- a/app/src/main/java/io/ably/example/androidpushexample/MainActivity.kt
+++ b/app/src/main/java/io/ably/example/androidpushexample/MainActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
+import android.preference.PreferenceManager
 import android.provider.Settings
 import android.util.Log
 import android.view.Menu
@@ -248,9 +249,23 @@ class MainActivity : AppCompatActivity() {
 		return true
 	}
 
-    fun clientId(): String{
-        return Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID)
-    }
+	fun clientId():String {
+		var pref = PreferenceManager.getDefaultSharedPreferences(this)
+		if (pref.contains("clientId")) {
+			return pref.getString("clientId", Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID))
+		}
+		var clientId = java.util.UUID.randomUUID().toString()
+		pref.edit().putString("clientId", clientId).apply()
+		return clientId
+	}
+
+	fun regenerateClientId():Boolean {
+		PreferenceManager.getDefaultSharedPreferences(this).edit().remove("clientId").apply()
+		var intent = Intent(this, MainActivity::class.java)
+		intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+		startActivity(intent)
+		return true
+	}
 
 	/**
 	 * Close the Ably connection. This removes any push channel subscription
@@ -820,8 +835,9 @@ class MainActivity : AppCompatActivity() {
 			R.id.action_reset_local_device -> resetLocalDevice()
 			R.id.action_get_activation_state -> getActivationState()
 			R.id.action_reset_activation_state -> resetActivationState()
-            R.id.action_push_subscribe_client -> pushSubscribeClient()
-            R.id.action_push_unsubscribe_client -> pushUnsubscribeClient()
+			R.id.action_push_subscribe_client -> pushSubscribeClient()
+			R.id.action_push_unsubscribe_client -> pushUnsubscribeClient()
+			R.id.action_regenerate_client_id -> regenerateClientId()
 			else -> super.onOptionsItemSelected(item)
 		}
 	}

--- a/app/src/main/java/io/ably/example/androidpushexample/MainActivity.kt
+++ b/app/src/main/java/io/ably/example/androidpushexample/MainActivity.kt
@@ -260,10 +260,16 @@ class MainActivity : AppCompatActivity() {
 	}
 
 	fun regenerateClientId():Boolean {
+		pushUnsubscribeClient()
 		PreferenceManager.getDefaultSharedPreferences(this).edit().remove("clientId").apply()
 		var intent = Intent(this, MainActivity::class.java)
 		intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
 		startActivity(intent)
+		return true
+	}
+
+	fun printClientId():Boolean {
+		logger.i("printClientId()", "Client ID: " + clientId())
 		return true
 	}
 
@@ -838,6 +844,7 @@ class MainActivity : AppCompatActivity() {
 			R.id.action_push_subscribe_client -> pushSubscribeClient()
 			R.id.action_push_unsubscribe_client -> pushUnsubscribeClient()
 			R.id.action_regenerate_client_id -> regenerateClientId()
+			R.id.action_get_client_id -> printClientId()
 			else -> super.onOptionsItemSelected(item)
 		}
 	}

--- a/app/src/main/res/menu/toolbar_menu.xml
+++ b/app/src/main/res/menu/toolbar_menu.xml
@@ -13,6 +13,13 @@
             android:title="Publish to channel"
             app:showAsAction="never"
     />
+
+    <item
+        android:id="@+id/action_get_client_id"
+        android:title="View ClientId"
+        app:showAsAction="never"
+    />
+
     <item
             android:id="@+id/action_push_subscribe"
             android:title="Subscribe to push channel (DeviceId)"
@@ -94,4 +101,5 @@
         android:title="Regenerate ClientId"
         app:showAsAction="never"
         />
+
 </menu>

--- a/app/src/main/res/menu/toolbar_menu.xml
+++ b/app/src/main/res/menu/toolbar_menu.xml
@@ -89,4 +89,9 @@
             android:title="Reset activation state"
             app:showAsAction="never"
     />
+    <item
+        android:id="@+id/action_regenerate_client_id"
+        android:title="Regenerate ClientId"
+        app:showAsAction="never"
+        />
 </menu>


### PR DESCRIPTION
* Randomly generate clientId and persist in SharedPref
* Regenerate Client option clears the persisted Id and generates a new one when clientId() is called next time.
